### PR TITLE
Fix for issue #1317

### DIFF
--- a/src/core/matchers/toThrowError.js
+++ b/src/core/matchers/toThrowError.js
@@ -70,8 +70,9 @@ getJasmineRequireObj().toThrowError = function(j$) {
     function getMatcher() {
       var expected = null,
           errorType = null;
-
-      if (arguments.length == 2) {
+	    if (arguments.length == 1) {
+		    errorType = Error;
+	    } else if (arguments.length == 2) {
         expected = arguments[1];
         if (isAnErrorType(expected)) {
           errorType = expected;


### PR DESCRIPTION
Proposed fix for issue #1317 - Calling toThrowError with no arguments errors via assuming the undefined argument is a regex

This fix adds another case for the getMatcher function, tol handle arguments list of size 1.